### PR TITLE
fix: hash IDs uses as key and convert to tinytext if not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 - Widened some columns that has potential or actual wider data than
   initially provided.
+- Transaction ID is md5-ed due to length > 255, the original ID is
+  kept as `id_real`.
 
 ## [0.1.0] – 2024-04-18
 

--- a/database/migrations/2024_10_16_100000_ragnarok_ruter_column_fixes.php
+++ b/database/migrations/2024_10_16_100000_ragnarok_ruter_column_fixes.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ruter_transactions', function (Blueprint $table) {
+            $table->char('id')->comment('Hashed version of Transaction ID.')->change();
+            $table->text('id_real')->comment('Transaction ID in UUID-ish format with appended string.')->after('id');
+            $table->unsignedInteger('ticket_type_id')->nullable()->comment('AKA product template ID')->change();
+        });
+        Schema::table('ruter_passengers', function (Blueprint $table) {
+            $table->text('product_id')->comment('Product ID')->change();
+            $table->text('profile_id')->comment('Product ID')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ruter_transactions', function (Blueprint $table) {
+            $table->dropColumn('id_real');
+        });
+    }
+};

--- a/src/Services/RuterTransactions.php
+++ b/src/Services/RuterTransactions.php
@@ -93,8 +93,10 @@ class RuterTransactions
     protected function insertTransaction(string $chunkId, array $json): void
     {
         $chunkDate = new Carbon($chunkId);
+        $transId = md5($json['id']);
         $this->transInserter->addRecord([
-            'id'                => $json['id'],
+            'id'                => $transId,
+            'id_real'           => $json['id'],
             'chunk_date'        => $chunkDate,
             'order_id'          => $json['orderId'],
             'order_date'        => $this->safeDate($json['orderDate']),
@@ -138,7 +140,7 @@ class RuterTransactions
             $this->paxInserter->addRecord([
                 'chunk_date'        => $chunkDate,
                 'transaction_pax_id' => $pax['id'],
-                'transaction_id'     => $json['id'],
+                'transaction_id'     => $transId,
                 'product_id'         => $pax['productId'],
                 'profile_id'         => $pax['profileId'],
                 'profile'            => $pax['profile'],


### PR DESCRIPTION
Some ID's are concatenations of three or more UUIDs causing it to be > 255 chars, choking index space of mysql. By `md5()`-ing these IDs or simply converting them to tinytex (if not indexed), we omit these problems